### PR TITLE
refactor: replace manual env overrides with caarlos0/env

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/caarlos0/env/v11 v11.4.0
 	github.com/deevus/truenas-go v0.4.0
 	github.com/spf13/cobra v1.10.2
 )

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,9 @@ al.essio.dev/pkg/shellescape v1.6.0 h1:NxFcEqzFSEVCGN2yq7Huv/9hyCEGVa/TncnOOBBeX
 al.essio.dev/pkg/shellescape v1.6.0/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/caarlos0/env/v11 v11.4.0 h1:Kcb6t5kIIr4XkoQC9AF2j+8E1Jsrl3Wz/hhm1LtoGAc=
+github.com/caarlos0/env/v11 v11.4.0/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/deevus/truenas-go v0.3.0 h1:IuJ7wm+aW0aSmm4AjW8GK6f+8bjKolj9BVd9bTfKeSU=
-github.com/deevus/truenas-go v0.3.0/go.mod h1:a5MwZEqT4NE8jwSA9BHONOAO8yH4kCaS5a+d4ad6sLA=
 github.com/deevus/truenas-go v0.4.0 h1:gESJ0naqtwzgdN1/gG5wBrp/Lm/5HF8xCBsRcwNgg78=
 github.com/deevus/truenas-go v0.4.0/go.mod h1:a5MwZEqT4NE8jwSA9BHONOAO8yH4kCaS5a+d4ad6sLA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -191,6 +191,34 @@ api_key = "file-key"
 	}
 }
 
+func TestEmptyEnvDoesNotOverrideDefault(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("PIXELS_DEFAULT_IMAGE", "")
+	t.Setenv("PIXELS_DEFAULT_POOL", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Defaults.Image != "ubuntu/24.04" {
+		t.Errorf("image = %q, want %q (empty env should not override default)", cfg.Defaults.Image, "ubuntu/24.04")
+	}
+	if cfg.Defaults.Pool != "tank" {
+		t.Errorf("pool = %q, want %q (empty env should not override default)", cfg.Defaults.Pool, "tank")
+	}
+}
+
+func TestInvalidEnvReturnsError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("PIXELS_TRUENAS_PORT", "not-a-number")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for invalid PIXELS_TRUENAS_PORT, got nil")
+	}
+}
+
 func TestProvisionEnvOverride(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)


### PR DESCRIPTION
## Summary

- Replace 15 manual `applyEnv*` calls and 4 helper functions with `env.Parse(cfg)` from `caarlos0/env/v11`
- Add explicit `env:"PIXELS_*"` struct tags to all config fields with env var overrides
- Add `TestEmptyEnvDoesNotOverrideDefault` to guard against future library behavior changes
- Net -24 lines, zero transitive dependencies added

## Details

The config loading had ~50 lines of boilerplate wiring each `PIXELS_*` env var to its config field via type-specific helpers (`applyEnv`, `applyEnvInt`, `applyEnvInt64`, `applyEnvBool`). `caarlos0/env` replaces all of it with struct tags and a single function call.

Chosen over `spf13/viper` (heavy deps, key-lowercasing friction) and `knadh/koanf` (non-mechanical env var naming makes `TransformFunc` awkward).

**Preserved behavior:**
- Config priority: TOML defaults < env vars < CLI flags
- `*bool` nil-when-unset semantics (pointer stays nil when env var absent)
- TOML loading, `expandHome`, `os.ExpandEnv` post-processing unchanged
- Error handling improved: invalid env values now surface errors instead of being silently ignored

## Test plan

- [x] `go build` compiles
- [x] `go test ./...` all 11 config tests pass (including env override, provision bool, empty env)
- [x] `go vet ./...` clean