### PR TITLE
refactor: extract shared retry package from pollUntil

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,58 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrTimeout is returned by Poll when the deadline expires without success.
+var ErrTimeout = errors.New("poll timed out")
+
+// Poll calls fn at the given interval until it returns (true, nil), a non-nil
+// error (fatal — stop immediately), or the timeout/context expires.
+func Poll(ctx context.Context, interval, timeout time.Duration, fn func(ctx context.Context) (bool, error)) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		done, err := fn(ctx)
+		if err != nil {
+			return err
+		}
+		if done {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("%w after %s", ErrTimeout, timeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+// Do calls fn up to attempts times, waiting delay between retries.
+// It returns nil on first success, or the last error if all attempts fail.
+// The delay between retries is context-aware.
+func Do(ctx context.Context, attempts int, delay time.Duration, fn func(ctx context.Context) error) error {
+	var lastErr error
+	for i := range attempts {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		lastErr = fn(ctx)
+		if lastErr == nil {
+			return nil
+		}
+	}
+	return lastErr
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,133 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Poll tests
+// ---------------------------------------------------------------------------
+
+func TestPoll_SuccessOnFirstCheck(t *testing.T) {
+	err := Poll(context.Background(), 10*time.Millisecond, time.Second, func(_ context.Context) (bool, error) {
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestPoll_SuccessAfterSeveralChecks(t *testing.T) {
+	calls := 0
+	err := Poll(context.Background(), 10*time.Millisecond, time.Second, func(_ context.Context) (bool, error) {
+		calls++
+		return calls >= 3, nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if calls < 3 {
+		t.Fatalf("expected at least 3 calls, got %d", calls)
+	}
+}
+
+func TestPoll_Timeout(t *testing.T) {
+	err := Poll(context.Background(), 10*time.Millisecond, 50*time.Millisecond, func(_ context.Context) (bool, error) {
+		return false, nil
+	})
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("expected ErrTimeout, got %v", err)
+	}
+}
+
+func TestPoll_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := Poll(ctx, 10*time.Millisecond, time.Second, func(_ context.Context) (bool, error) {
+		return false, nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestPoll_FatalErrorStopsPolling(t *testing.T) {
+	fatal := errors.New("fatal failure")
+	calls := 0
+	err := Poll(context.Background(), 10*time.Millisecond, time.Second, func(_ context.Context) (bool, error) {
+		calls++
+		return false, fatal
+	})
+	if !errors.Is(err, fatal) {
+		t.Fatalf("expected fatal error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Do tests
+// ---------------------------------------------------------------------------
+
+func TestDo_SuccessOnFirstAttempt(t *testing.T) {
+	err := Do(context.Background(), 3, 10*time.Millisecond, func(_ context.Context) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestDo_SuccessAfterRetries(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), 5, 10*time.Millisecond, func(_ context.Context) error {
+		calls++
+		if calls < 3 {
+			return errors.New("not yet")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDo_AllAttemptsExhausted(t *testing.T) {
+	lastErr := errors.New("persistent failure")
+	err := Do(context.Background(), 3, 10*time.Millisecond, func(_ context.Context) error {
+		return lastErr
+	})
+	if !errors.Is(err, lastErr) {
+		t.Fatalf("expected last error, got %v", err)
+	}
+}
+
+func TestDo_ContextCancellationDuringDelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := Do(ctx, 5, time.Second, func(_ context.Context) error {
+		calls++
+		if calls == 1 {
+			// Cancel during the delay before the next retry.
+			cancel()
+		}
+		return errors.New("fail")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call before cancellation, got %d", calls)
+	}
+}

--- a/internal/ssh/ssh_test.go
+++ b/internal/ssh/ssh_test.go
@@ -1,62 +1,10 @@
 package ssh
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
-	"time"
 )
-
-func TestPollUntil_ImmediateSuccess(t *testing.T) {
-	err := pollUntil(context.Background(), 10*time.Millisecond, time.Second, func(ctx context.Context) bool {
-		return true
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestPollUntil_SucceedsAfterRetries(t *testing.T) {
-	calls := 0
-	err := pollUntil(context.Background(), 10*time.Millisecond, time.Second, func(ctx context.Context) bool {
-		calls++
-		return calls >= 3
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if calls < 3 {
-		t.Errorf("expected at least 3 calls, got %d", calls)
-	}
-}
-
-func TestPollUntil_Timeout(t *testing.T) {
-	err := pollUntil(context.Background(), 10*time.Millisecond, 50*time.Millisecond, func(ctx context.Context) bool {
-		return false
-	})
-	if err == nil {
-		t.Fatal("expected timeout error, got nil")
-	}
-	if got := err.Error(); got != "timed out after 50ms" {
-		t.Errorf("error = %q, want timeout message", got)
-	}
-}
-
-func TestPollUntil_ContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	err := pollUntil(ctx, 10*time.Millisecond, time.Second, func(ctx context.Context) bool {
-		return false
-	})
-	if err == nil {
-		t.Fatal("expected context error, got nil")
-	}
-	if err != context.Canceled {
-		t.Errorf("error = %v, want context.Canceled", err)
-	}
-}
 
 func TestConsole_SSHNotFound(t *testing.T) {
 	t.Setenv("PATH", t.TempDir()) // empty dir, no ssh binary


### PR DESCRIPTION
## Summary

- Extract `pollUntil` from `internal/ssh` into new `internal/retry` package with two exported functions
- Fix context cancellation in destroy retry and IP polling loops
- Add `ErrTimeout` sentinel for distinguishing timeout from fatal errors
- 9 new tests, zero new dependencies

## Details

### `retry.Poll(ctx, interval, timeout, fn) error`
Context-aware polling with enhanced callback signature `func(ctx) (bool, error)`. Callers can now signal fatal errors to stop polling immediately. Invokes `fn` immediately (no wasted first-tick delay). Returns `ErrTimeout` on deadline.

### `retry.Do(ctx, attempts, delay, fn) error`
Retry-on-failure with context-aware delays via `select` (replaces `time.Sleep` which ignored cancellation).

### Migration
- `WaitProvisioned` in `ssh.go` → `retry.Poll` (old `pollUntil` deleted)
- IP polling in `create.go` → `retry.Poll` (timeout ignored, API errors propagated)
- Delete retry in `destroy.go` → `retry.Do` (fixed: now responds to Ctrl+C during 2s sleep)
- `WaitReady` stays as-is (specialized TCP dial + progress logging)

## Test plan

- [x] `go build` compiles
- [x] `go test ./...` all pass (9 new retry tests + existing tests)
- [x] `go vet ./...` clean